### PR TITLE
Fix double-redirect to "/editor/"

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       <nav class="nav">
         <div class="nav__inner">
           <div class="nav__toolbox">
-            <a href="http://maputnik.github.io/editor" class="button">Launch</a><!--
+            <a href="/editor/" class="button">Launch</a><!--
             --><a href="https://github.com/maputnik/editor/wiki" class="button">Docs</a>
           </div>
         </div>
@@ -102,7 +102,7 @@
             Give it a try right now, no signup or download required
           </p>
           <p>
-            <a class="call-to-action__button" href="http://maputnik.github.io/editor">
+            <a class="call-to-action__button" href="/editor/">
               Launch Maputnik!
             </a>
           </p>
@@ -116,7 +116,7 @@
           </p>
           <div class="showcase__items">
             <div class="showcase__item">
-              <a href="http://maputnik.github.io/editor?style=https://rawgit.com/openmaptiles/positron-gl-style/master/style.json">
+              <a href="/editor/?style=https://rawgit.com/openmaptiles/positron-gl-style/master/style.json">
                 <div class="showcase__item__img showcase__item__img--positron"></div>
                 <div class="showcase__item__title">
                   Positron
@@ -124,7 +124,7 @@
               </a>
             </div>
             <div class="showcase__item">
-              <a href="http://maputnik.github.io/editor?style=https://rawgit.com/lukasmartinelli/osm-liberty/gh-pages/style.json">
+              <a href="/editor/?style=https://rawgit.com/lukasmartinelli/osm-liberty/gh-pages/style.json">
                 <div class="showcase__item__img showcase__item__img--osm-liberty"></div>
                 <div class="showcase__item__title">
                   OSM Liberty
@@ -132,7 +132,7 @@
               </a>
             </div>
             <div class="showcase__item">
-              <a href="http://maputnik.github.io/editor?style=https://rawgit.com/openmaptiles/fiord-color-gl-style/master/style.json">
+              <a href="/editor/?style=https://rawgit.com/openmaptiles/fiord-color-gl-style/master/style.json">
                 <div class="showcase__item__img showcase__item__img--fiord-color"></div>
                 <div class="showcase__item__title">
                   Fiord Color


### PR DESCRIPTION
Hello.
There are two redirects from http://maputnik.github.io/editor to https://maputnik.github.io/editor/.