### PR TITLE
Stop overflow of the x-axis in chrome

### DIFF
--- a/css/website.scss
+++ b/css/website.scss
@@ -2,6 +2,7 @@
 ---
 html {
   box-sizing: border-box;
+  overflow-x: hidden;
 }
 *, *:before, *:after {
   box-sizing: inherit;


### PR DESCRIPTION
Currently the screenshot overflows, prevent anything from overflowing the x-axis